### PR TITLE
Add macOS Apple Silicon support (cross-platform)

### DIFF
--- a/src/AirMaster7pConnect.csproj
+++ b/src/AirMaster7pConnect.csproj
@@ -1,25 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <PublishSingleFile>True</PublishSingleFile>
         <SelfContained>true</SelfContained>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.5"/>
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.5"/>
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.5"/>
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.5"/>
+        <PackageReference Include="Avalonia" Version="11.2.3"/>
+        <PackageReference Include="Avalonia.Desktop" Version="11.2.3"/>
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3"/>
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3"/>
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.5"/>
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3"/>
         <PackageReference Include="Sandwych.SmartConfig" Version="1.1.0.30" />
-        <PackageReference Include="SimpleWifi.netstandard" Version="2.0.0" />
     </ItemGroup>
 </Project>

--- a/src/AirMaster7pConnect.csproj
+++ b/src/AirMaster7pConnect.csproj
@@ -8,10 +8,14 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <PublishSingleFile>True</PublishSingleFile>
         <SelfContained>true</SelfContained>
-        <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     </PropertyGroup>
-    
+
+    <!-- Define IS_WINDOWS when building on Windows so #if guards compile correctly -->
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+        <DefineConstants>$(DefineConstants);IS_WINDOWS</DefineConstants>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.2.3"/>
         <PackageReference Include="Avalonia.Desktop" Version="11.2.3"/>
@@ -20,5 +24,6 @@
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3"/>
         <PackageReference Include="Sandwych.SmartConfig" Version="1.1.0.30" />
+        <PackageReference Include="SimpleWifi.netstandard" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     </ItemGroup>
 </Project>

--- a/src/ViewModels/MainViewModel.cs
+++ b/src/ViewModels/MainViewModel.cs
@@ -3,7 +3,12 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
+#if IS_WINDOWS
+using SimpleWifi.Win32;
+#endif
 
 namespace AirMaster7pConnect.ViewModels;
 
@@ -51,7 +56,7 @@ public class MainViewModel : BaseViewModel
 
         return ValueTask.CompletedTask;
     }
-    
+
     public async void Connect()
     {
         if (!PhysicalAddress.TryParse(Bssid.Replace(':', '-'), out var bssid))
@@ -59,20 +64,20 @@ public class MainViewModel : BaseViewModel
             await SetContentAsync("BSSID format invalid (example: 01:02:03:04:05:06)");
             return;
         }
-        
+
         var wifiInterface = GetWifiInterface();
         if (wifiInterface == null)
         {
             await SetContentAsync("Cannot find any available WiFi adapter");
             return;
         }
-        
+
         var localAddress = wifiInterface.GetIPProperties()
             .UnicastAddresses
             .Where(x => x.Address.AddressFamily == AddressFamily.InterNetwork)
             .Select(x => x.Address)
             .FirstOrDefault();
-        
+
         if(localAddress == null)
         {
             await SetContentAsync($"Cannot find IPv4 address for WiFi interface: {wifiInterface.Name}");
@@ -85,6 +90,14 @@ public class MainViewModel : BaseViewModel
     }
 
     public async void UseCurrentConnection()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            await UseCurrentConnectionMacOS();
+        else
+            await UseCurrentConnectionWindows();
+    }
+
+    private async Task UseCurrentConnectionMacOS()
     {
         try
         {
@@ -110,6 +123,37 @@ public class MainViewModel : BaseViewModel
         {
             await SetContentAsync("Could not detect WiFi. Fill in fields manually.");
         }
+    }
+
+    private async Task UseCurrentConnectionWindows()
+    {
+#if IS_WINDOWS
+        var wifiInterface = GetWifiInterface();
+        if (wifiInterface == null)
+        {
+            await SetContentAsync("Cannot find any available WiFi adapter");
+            return;
+        }
+
+        var wlan = new WlanClient();
+        foreach (var wifi in wlan.Interfaces)
+        {
+            if (wifi.NetworkInterface.Id != wifiInterface.Id)
+                continue;
+
+            var connection = wifi.CurrentConnection.wlanAssociationAttributes;
+            int length = connection.dot11Ssid.SSID.AsSpan().IndexOf((byte)0);
+            Ssid = Encoding.UTF8.GetString(connection.dot11Ssid.SSID, 0, length);
+            Bssid = string.Join(":", connection.dot11Bssid.Select(x => $"{x:X2}"));
+            if ((int)connection.dot11PhyType > 7)
+                await SetContentAsync("AirMaster can't connect to 5GHz Wi-Fi.\nReconnect to 2.4Ghz or fill fields manually.");
+        }
+
+        if (Content is string)
+            await SetContentAsync(null);
+#else
+        await SetContentAsync("WiFi detection is not supported on this platform. Fill in fields manually.");
+#endif
     }
 
     private static NetworkInterface? GetWifiInterface()

--- a/src/ViewModels/MainViewModel.cs
+++ b/src/ViewModels/MainViewModel.cs
@@ -1,10 +1,9 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading.Tasks;
-using SimpleWifi.Win32;
 
 namespace AirMaster7pConnect.ViewModels;
 
@@ -87,29 +86,30 @@ public class MainViewModel : BaseViewModel
 
     public async void UseCurrentConnection()
     {
-        var wifiInterface = GetWifiInterface();
-        if (wifiInterface == null)
+        try
         {
-            await SetContentAsync("Cannot find any available WiFi adapter");
-            return;
+            var process = new Process();
+            process.StartInfo.FileName = "/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport";
+            process.StartInfo.Arguments = "-I";
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.UseShellExecute = false;
+            process.Start();
+            var output = await process.StandardOutput.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            foreach (var line in output.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith("SSID:"))
+                    Ssid = trimmed.Substring(5).Trim();
+                else if (trimmed.StartsWith("BSSID:"))
+                    Bssid = trimmed.Substring(6).Trim();
+            }
         }
-        
-        var wlan = new WlanClient();
-        foreach (var wifi in wlan.Interfaces)
+        catch
         {
-            if (wifi.NetworkInterface.Id != wifiInterface.Id)
-                continue;
-
-            var connection = wifi.CurrentConnection.wlanAssociationAttributes;
-            int length = connection.dot11Ssid.SSID.AsSpan().IndexOf((byte)0);
-            Ssid = Encoding.UTF8.GetString(connection.dot11Ssid.SSID, 0, length);
-            Bssid = string.Join(":", connection.dot11Bssid.Select(x => $"{x:X2}"));
-            if ((int)connection.dot11PhyType > 7)
-                await SetContentAsync("AirMaster can't connect to 5GHz Wi-Fi.\nReconnect to 2.4Ghz or fill fields manually.");
+            await SetContentAsync("Could not detect WiFi. Fill in fields manually.");
         }
-
-        if (Content is string)
-            await SetContentAsync(null);
     }
 
     private static NetworkInterface? GetWifiInterface()


### PR DESCRIPTION
## Summary
- Adds macOS Apple Silicon support **while keeping Windows support intact**
- Upgrades Avalonia packages from 11.0.5 to 11.2.3
- Upgrades target framework from .NET 6 to .NET 10
- Removes hardcoded `RuntimeIdentifier` — specify at publish time (`-r win-x64` or `-r osx-arm64`)
- Adds macOS WiFi detection via `airport -I` CLI alongside existing Windows `WlanClient`

## Changes
- **`src/AirMaster7pConnect.csproj`**
  - Removed hardcoded `RuntimeIdentifier` (pass `-r win-x64` or `-r osx-arm64` at publish time)
  - `SimpleWifi.netstandard` conditionally included only on Windows builds
  - Defines `IS_WINDOWS` preprocessor symbol on Windows for `#if` guards
  - Updated Avalonia 11.0.5 → 11.2.3

- **`src/ViewModels/MainViewModel.cs`**
  - `UseCurrentConnection()` now branches by OS at runtime (`RuntimeInformation.IsOSPlatform`)
  - `UseCurrentConnectionWindows()` — original `WlanClient` logic, guarded by `#if IS_WINDOWS`
  - `UseCurrentConnectionMacOS()` — new `airport -I` based detection

## Publishing
```bash
# Windows
dotnet publish -r win-x64

# macOS Apple Silicon
dotnet publish -r osx-arm64
```